### PR TITLE
fix: allow some arguments to be unset

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,4 +7,4 @@
 # the repo. Unless a later match takes precedence,
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
-*       @jbristow @zprobst @ccloes @asantos4 @rreddy15 @aghafari @alucas7
+*       @jbristow @zprobst @ccloes @angelosantos4

--- a/nodestream_github/client/githubclient.py
+++ b/nodestream_github/client/githubclient.py
@@ -26,7 +26,7 @@ from nodestream_github.logging import get_plugin_logger
 DEFAULT_REQUEST_RATE_LIMIT_PER_MINUTE = int(13000 / 60)
 DEFAULT_MAX_RETRIES = 20
 DEFAULT_PAGE_SIZE = 100
-DEFAULT_MAX_RETRY_WAIT_SECONDS = 300 # 5 minutes
+DEFAULT_MAX_RETRY_WAIT_SECONDS = 300  # 5 minutes
 
 
 logger = get_plugin_logger(__name__)

--- a/nodestream_github/repos.py
+++ b/nodestream_github/repos.py
@@ -97,7 +97,6 @@ class GithubReposExtractor(Extractor):
                 owner["login"], repo["name"]
             )
         ]
-        logger.info("owner=%s", owner)
         repo["webhooks"] = [
             hook
             async for hook in self.client.fetch_webhooks_for_repo(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nodestream-plugin-github"
-version = "0.13.1-beta.2"
+version = "0.13.1-beta.3"
 description = ""
 authors = ["Jon Bristow <jonathan_bristow@intuit.com>"]
 packages = [


### PR DESCRIPTION
# Summary of Change

Some config options are optional, but to use them they need to be allowed to be passed in as null. Defaults don't work exactly as you might expect.

## Before Review
- [X] Unit Tests are Added/Updated and meet at-least 85% coverage criteria for that feature

## Before Merge
- [X] Ran/Functionally Tested in Dev Environment
- [X] Documentation Is Updated (Where Appropriate)
