### PR TITLE
fix: allow all client args to be null

### DIFF
--- a/nodestream_github/github_teams.yaml
+++ b/nodestream_github/github_teams.yaml
@@ -14,7 +14,6 @@
         node_id: !jmespath 'node_id'
       additional_indexes:
         - slug
-        - name
         - html_url
     - type: properties
       properties:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nodestream-plugin-github"
-version = "0.13.1-beta.3"
+version = "0.13.1-beta.4"
 description = ""
 authors = ["Jon Bristow <jonathan_bristow@intuit.com>"]
 packages = [

--- a/tests/client/test_githubclient.py
+++ b/tests/client/test_githubclient.py
@@ -83,3 +83,8 @@ async def test_pagination(httpx_mock: HTTPXMock):
 
     items = [item async for item in client._get_paginated("example")]
     assert items == ["a", "b", "c", "d"]
+
+
+def test_all_null_args():
+    # noinspection PyTypeChecker
+    assert GithubRestApiClient(auth_token=None, github_hostname=None)


### PR DESCRIPTION
# Summary of Change

When running `nodestream audit`, null values are sent to all plugin pipelines whether they are named in the `nodestream.yaml`

## Before Review
- [x] Unit Tests are Added/Updated and meet at-least 85% coverage criteria for that feature

## Before Merge
- [x] Ran/Functionally Tested in Dev Environment
- [x] Documentation Is Updated (Where Appropriate)
