### PR TITLE
Limit repo collaborators to outside and direct affiliations.

### DIFF
--- a/nodestream_github/client/githubclient.py
+++ b/nodestream_github/client/githubclient.py
@@ -390,9 +390,7 @@ class GithubRestApiClient:
             _fetch_problem(f"webhooks for repo {owner_login}/{repo_name}", e)
 
     async def fetch_collaborators_for_repo(
-        self,
-        owner_login: str,
-        repo_name: str,
+        self, owner_login: str, repo_name: str, affiliation: str
     ) -> AsyncGenerator[types.GithubUser]:
         """Try to get collaborator data for this repo.
 
@@ -415,7 +413,8 @@ class GithubRestApiClient:
         """
         try:
             async for collab_resp in self._get_paginated(
-                f"repos/{owner_login}/{repo_name}/collaborators"
+                f"repos/{owner_login}/{repo_name}/collaborators",
+                params={"affiliation": affiliation},
             ):
                 yield collab_resp
 

--- a/nodestream_github/github_repos.yaml
+++ b/nodestream_github/github_repos.yaml
@@ -84,6 +84,7 @@
       key_normalization:
         do_lowercase_strings: false
       relationship_properties:
+        "affiliation": !jmespath "affiliation"
         "permission": !jmespath "role_name"
 
     - type: relationship

--- a/nodestream_github/interpretations/relationship/user.py
+++ b/nodestream_github/interpretations/relationship/user.py
@@ -13,11 +13,19 @@ from nodestream_github.types import GithubUser, SimplifiedUser
 _USER_KEYS_TO_PRESERVE = ["id", "login", "node_id", "role", "role_name"]
 
 
-def simplify_user(user: GithubUser) -> SimplifiedUser:
+def simplify_user(
+    user: GithubUser,
+    *,
+    affiliation: str | None = None,
+) -> SimplifiedUser:
     """Simplify user data.
 
     Allows us to only keep a consistent minimum for relationship data."""
-    return {k: user[k] for k in _USER_KEYS_TO_PRESERVE if k in user}
+    output = {k: user[k] for k in _USER_KEYS_TO_PRESERVE if k in user}
+
+    if affiliation:
+        output["affiliation"] = affiliation
+    return output
 
 
 class UserRelationshipInterpretation(

--- a/nodestream_github/repos.py
+++ b/nodestream_github/repos.py
@@ -103,12 +103,21 @@ class GithubReposExtractor(Extractor):
                 owner["login"], repo["name"]
             )
         ]
-        repo["collaborators"] = [
-            simplify_user(user)
-            async for user in self.client.fetch_collaborators_for_repo(
-                owner["login"], repo["name"]
-            )
-        ]
+        repo["collaborators"] = []
+
+        async for user in self.client.fetch_collaborators_for_repo(
+            owner["login"],
+            repo["name"],
+            "direct",
+        ):
+            repo["collaborators"].append(simplify_user(user, affiliation="direct"))
+        async for user in self.client.fetch_collaborators_for_repo(
+            owner["login"],
+            repo["name"],
+            "outside",
+        ):
+            repo["collaborators"].append(simplify_user(user, affiliation="outside"))
+
         logger.debug("yielded GithubRepo{full_name=%s}", repo["full_name"])
         return repo
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -108,19 +108,19 @@ uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
 name = "boto3"
-version = "1.36.10"
+version = "1.36.13"
 description = "The AWS SDK for Python"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 markers = "sys_platform == \"darwin\" or sys_platform == \"linux\" or sys_platform != \"darwin\" and sys_platform != \"linux\""
 files = [
-    {file = "boto3-1.36.10-py3-none-any.whl", hash = "sha256:5f8d5c2024a2d1411d3d67abb7357ec7d4c6162e3f1c396dc9b79d042cfd0a80"},
-    {file = "boto3-1.36.10.tar.gz", hash = "sha256:d2f1010db699326b26fbd465d91c4b49177c9d995d7e72c0f31335f139efa0d2"},
+    {file = "boto3-1.36.13-py3-none-any.whl", hash = "sha256:20d97739cea1b0f549e9096c453ac727a350da28bd0451098714260b655a85ea"},
+    {file = "boto3-1.36.13.tar.gz", hash = "sha256:c8031aa1c4a7c331081b2d86c49a362654b86e0b89d0a41fa166a68b226f4aba"},
 ]
 
 [package.dependencies]
-botocore = ">=1.36.10,<1.37.0"
+botocore = ">=1.36.13,<1.37.0"
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.11.0,<0.12.0"
 
@@ -129,15 +129,15 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.36.10"
+version = "1.36.13"
 description = "Low-level, data-driven core of boto 3."
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 markers = "sys_platform == \"darwin\" or sys_platform == \"linux\" or sys_platform != \"darwin\" and sys_platform != \"linux\""
 files = [
-    {file = "botocore-1.36.10-py3-none-any.whl", hash = "sha256:45c8a6e01dc18d44a13ba688f1d60ad562db8154b08c46b412387ea040a741c2"},
-    {file = "botocore-1.36.10.tar.gz", hash = "sha256:d27bb73f0ea81395527a6298ac0a7ea5b2958094169f7cf7d48e3f4e4bc21b65"},
+    {file = "botocore-1.36.13-py3-none-any.whl", hash = "sha256:d644a814440bf8d55f4e29b1c0e6f021e2573b7784e0c91f55f4d9d689e08005"},
+    {file = "botocore-1.36.13.tar.gz", hash = "sha256:50a3ff292f8dfdde21074b5c916afe847b01e074ab16d9c9fe71b34960c77134"},
 ]
 
 [package.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nodestream-plugin-github"
-version = "0.13.1-beta.5"
+version = "0.13.1-beta.6"
 description = ""
 authors = ["Jon Bristow <jonathan_bristow@intuit.com>"]
 packages = [

--- a/tests/mocks/githubrest.py
+++ b/tests/mocks/githubrest.py
@@ -131,10 +131,10 @@ class GithubHttpxMock:
         )
 
     def get_collaborators_for_repo(
-        self, owner_login: str, repo_name: str, **kwargs: any
+        self, owner_login: str, repo_name: str, affiliation: str, **kwargs: any
     ) -> None:
         self.add_response(
-            url=f"{self.base_url}/repos/{owner_login}/{repo_name}/collaborators?per_page={self.per_page}",
+            url=f"{self.base_url}/repos/{owner_login}/{repo_name}/collaborators?per_page={self.per_page}&affiliation={affiliation}",
             **kwargs,
         )
 


### PR DESCRIPTION
# Summary of Change

Since permissions granted via org owner, team membership, and default org repo permissions are all captured in other parts of the graph the `IS_COLLABORATOR` relationship will now be limited to outside and direct affiliated contributors. (Affiliation will be marked as a property on the relationship)

## Before Review
- [x] Unit Tests are Added/Updated and meet at-least 85% coverage criteria for that feature

## Before Merge
- [x] Ran/Functionally Tested in Dev Environment
- [x] Documentation Is Updated (Where Appropriate)
