### PR TITLE
Adding GitHub Audit Log Extractor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,3 +28,6 @@ lint: fmt
 test:
 	poetry run pytest
 
+.PHONY: coverage
+coverage:
+	poetry run coverage html

--- a/nodestream_github/__init__.py
+++ b/nodestream_github/__init__.py
@@ -10,6 +10,7 @@ from .teams import GithubTeamsExtractor
 from .users import GithubUserExtractor
 
 __all__ = (
+    "GithubAuditLogExtractor",
     "GithubOrganizationsExtractor",
     "GithubPlugin",
     "GithubReposExtractor",
@@ -17,5 +18,4 @@ __all__ = (
     "GithubUserExtractor",
     "RepositoryRelationshipInterpretation",
     "UserRelationshipInterpretation",
-    "GithubAuditLogExtractor",
 )

--- a/nodestream_github/__init__.py
+++ b/nodestream_github/__init__.py
@@ -1,3 +1,4 @@
+from .audit import GithubAuditLogExtractor
 from .interpretations import (
     RepositoryRelationshipInterpretation,
     UserRelationshipInterpretation,
@@ -16,4 +17,5 @@ __all__ = (
     "GithubUserExtractor",
     "RepositoryRelationshipInterpretation",
     "UserRelationshipInterpretation",
+    "GithubAuditLogExtractor",
 )

--- a/nodestream_github/audit.py
+++ b/nodestream_github/audit.py
@@ -19,14 +19,14 @@ logger = get_plugin_logger(__name__)
 
 class GithubAuditLogExtractor(Extractor):
     def __init__(
-        self, enterprise_name: str, events: List[str], **github_client_kwargs: any
+        self, enterprise_name: str, actions: List[str], **github_client_kwargs: any
     ):
         self.enterprise_name = enterprise_name
         self.client = GithubRestApiClient(**github_client_kwargs)
-        self.events = events
+        self.actions = actions
 
     async def extract_records(self) -> AsyncGenerator[GithubAuditLog]:
         async for audit in self.client.fetch_enterprise_audit_log(
-            self.enterprise_name, self.events
+            self.enterprise_name, self.actions
         ):
             yield audit

--- a/nodestream_github/audit.py
+++ b/nodestream_github/audit.py
@@ -22,7 +22,7 @@ class GithubAuditLogExtractor(Extractor):
     You can pass the enterprise_name, actions and lookback_period to the extractor
     along with the regular GitHub parameters.
 
-    lookback_period can contain keys for days, months, and/or years. The value for the keys should be ints
+    lookback_period can contain keys for days, months, and/or years as ints
     actions can be found in the GitHub documentation
     https://docs.github.com/en/enterprise-cloud@latest/admin/monitoring-activity-in-your-enterprise/reviewing-audit-logs-for-your-enterprise/searching-the-audit-log-for-your-enterprise#search-based-on-the-action-performed
     """

--- a/nodestream_github/audit.py
+++ b/nodestream_github/audit.py
@@ -42,5 +42,5 @@ class GithubAuditLogExtractor(Extractor):
         async for audit in self.client.fetch_enterprise_audit_log(
             self.enterprise_name, self.actions, self.lookback_period
         ):
-            audit['timestamp'] = audit['@timestamp']
+            audit['timestamp'] = audit.pop('@timestamp')
             yield audit

--- a/nodestream_github/audit.py
+++ b/nodestream_github/audit.py
@@ -6,6 +6,7 @@ https://docs.github.com/en/enterprise-server@3.12/rest?apiVersion=2022-11-28
 """
 
 from collections.abc import AsyncGenerator
+from typing import Any
 
 from nodestream.pipeline import Extractor
 
@@ -32,7 +33,7 @@ class GithubAuditLogExtractor(Extractor):
         enterprise_name: str,
         actions: list[str] | None = None,
         lookback_period: dict[str, int] | None = None,
-        **github_client_kwargs: any,
+        **github_client_kwargs: dict[str, Any] | None,
     ):
         self.enterprise_name = enterprise_name
         self.client = GithubRestApiClient(**github_client_kwargs)

--- a/nodestream_github/audit.py
+++ b/nodestream_github/audit.py
@@ -18,20 +18,21 @@ logger = get_plugin_logger(__name__)
 
 class GithubAuditLogExtractor(Extractor):
     """
-        Extracts audit logs from the GitHub REST API.
-        You can pass the enterprise_name, actions and lookback_period to the extractor
-        along with the regular GitHub parameters.
+    Extracts audit logs from the GitHub REST API.
+    You can pass the enterprise_name, actions and lookback_period to the extractor
+    along with the regular GitHub parameters.
 
-        lookback_period can contain keys for days, months, and/or years. The value for the keys should be ints
-        actions can be found in the GitHub documentation
-        https://docs.github.com/en/enterprise-cloud@latest/admin/monitoring-activity-in-your-enterprise/reviewing-audit-logs-for-your-enterprise/searching-the-audit-log-for-your-enterprise#search-based-on-the-action-performed
+    lookback_period can contain keys for days, months, and/or years. The value for the keys should be ints
+    actions can be found in the GitHub documentation
+    https://docs.github.com/en/enterprise-cloud@latest/admin/monitoring-activity-in-your-enterprise/reviewing-audit-logs-for-your-enterprise/searching-the-audit-log-for-your-enterprise#search-based-on-the-action-performed
     """
+
     def __init__(
         self,
         enterprise_name: str,
         actions: list[str] | None = None,
         lookback_period: dict[str, int] | None = None,
-        **github_client_kwargs: any
+        **github_client_kwargs: any,
     ):
         self.enterprise_name = enterprise_name
         self.client = GithubRestApiClient(**github_client_kwargs)

--- a/nodestream_github/audit.py
+++ b/nodestream_github/audit.py
@@ -17,15 +17,30 @@ logger = get_plugin_logger(__name__)
 
 
 class GithubAuditLogExtractor(Extractor):
+    """
+        Extracts audit logs from the GitHub REST API.
+        You can pass the enterprise_name, actions and lookback_period to the extractor
+        along with the regular GitHub parameters.
+
+        lookback_period can contain keys for days, months, and/or years. The value for the keys should be ints
+        actions can be found in the GitHub documentation
+        https://docs.github.com/en/enterprise-cloud@latest/admin/monitoring-activity-in-your-enterprise/reviewing-audit-logs-for-your-enterprise/searching-the-audit-log-for-your-enterprise#search-based-on-the-action-performed
+    """
     def __init__(
-        self, enterprise_name: str, actions: list[str], **github_client_kwargs: any
+        self,
+        enterprise_name: str,
+        actions: list[str] | None = None,
+        lookback_period: dict[str, int] | None = None,
+        **github_client_kwargs: any
     ):
         self.enterprise_name = enterprise_name
         self.client = GithubRestApiClient(**github_client_kwargs)
+        self.lookback_period = lookback_period
         self.actions = actions
 
     async def extract_records(self) -> AsyncGenerator[GithubAuditLog]:
         async for audit in self.client.fetch_enterprise_audit_log(
-            self.enterprise_name, self.actions
+            self.enterprise_name, self.actions, self.lookback_period
         ):
+            audit['timestamp'] = audit['@timestamp']
             yield audit

--- a/nodestream_github/audit.py
+++ b/nodestream_github/audit.py
@@ -24,7 +24,7 @@ class GithubAuditLogExtractor(Extractor):
 
     lookback_period can contain keys for days, months, and/or years as ints
     actions can be found in the GitHub documentation
-    https://docs.github.com/en/enterprise-cloud@latest/admin/monitoring-activity-in-your-enterprise/reviewing-audit-logs-for-your-enterprise/searching-the-audit-log-for-your-enterprise#search-based-on-the-action-performed
+    https://docs.github.com/en/enterprise-server@3.12/admin/monitoring-activity-in-your-enterprise/reviewing-audit-logs-for-your-enterprise/searching-the-audit-log-for-your-enterprise#search-based-on-the-action-performed
     """
 
     def __init__(

--- a/nodestream_github/audit.py
+++ b/nodestream_github/audit.py
@@ -6,7 +6,6 @@ https://docs.github.com/en/enterprise-server@3.12/rest?apiVersion=2022-11-28
 """
 
 from collections.abc import AsyncGenerator
-from typing import List
 
 from nodestream.pipeline import Extractor
 
@@ -19,7 +18,7 @@ logger = get_plugin_logger(__name__)
 
 class GithubAuditLogExtractor(Extractor):
     def __init__(
-        self, enterprise_name: str, actions: List[str], **github_client_kwargs: any
+        self, enterprise_name: str, actions: list[str], **github_client_kwargs: any
     ):
         self.enterprise_name = enterprise_name
         self.client = GithubRestApiClient(**github_client_kwargs)

--- a/nodestream_github/audit.py
+++ b/nodestream_github/audit.py
@@ -42,5 +42,5 @@ class GithubAuditLogExtractor(Extractor):
         async for audit in self.client.fetch_enterprise_audit_log(
             self.enterprise_name, self.actions, self.lookback_period
         ):
-            audit['timestamp'] = audit.pop('@timestamp')
+            audit["timestamp"] = audit.pop("@timestamp")
             yield audit

--- a/nodestream_github/audit.py
+++ b/nodestream_github/audit.py
@@ -1,0 +1,32 @@
+"""
+Nodestream Extractor that extracts audit logs from the GitHub REST API.
+
+Developed using Enterprise Server 3.12
+https://docs.github.com/en/enterprise-server@3.12/rest?apiVersion=2022-11-28
+"""
+
+from collections.abc import AsyncGenerator
+from typing import List
+
+from nodestream.pipeline import Extractor
+
+from .client import GithubRestApiClient
+from .logging import get_plugin_logger
+from .types import GithubAuditLog
+
+logger = get_plugin_logger(__name__)
+
+
+class GithubAuditLogExtractor(Extractor):
+    def __init__(
+        self, enterprise_name: str, events: List[str], **github_client_kwargs: any
+    ):
+        self.enterprise_name = enterprise_name
+        self.client = GithubRestApiClient(**github_client_kwargs)
+        self.events = events
+
+    async def extract_records(self) -> AsyncGenerator[GithubAuditLog]:
+        async for audit in self.client.fetch_enterprise_audit_log(
+            self.enterprise_name, self.events
+        ):
+            yield audit

--- a/nodestream_github/client/githubclient.py
+++ b/nodestream_github/client/githubclient.py
@@ -7,10 +7,10 @@ import json
 import logging
 from collections.abc import AsyncGenerator
 from datetime import datetime
-from dateutil.relativedelta import *
 from enum import Enum
 
 import httpx
+from dateutil.relativedelta import *
 from limits import RateLimitItem, RateLimitItemPerMinute
 from limits.aio.storage import MemoryStorage
 from limits.aio.strategies import MovingWindowRateLimiter, RateLimiter

--- a/nodestream_github/client/githubclient.py
+++ b/nodestream_github/client/githubclient.py
@@ -7,7 +7,6 @@ import json
 import logging
 from collections.abc import AsyncGenerator
 from enum import Enum
-from typing import List
 
 import httpx
 from limits import RateLimitItem, RateLimitItemPerMinute
@@ -329,7 +328,7 @@ class GithubRestApiClient:
             _fetch_problem("all organizations", e)
 
     async def fetch_enterprise_audit_log(
-        self, enterprise_name: str, actions: List[str]
+        self, enterprise_name: str, actions: list[str]
     ) -> AsyncGenerator[types.GithubAuditLog]:
         """Fetches enterprise-wide audit log data
 

--- a/nodestream_github/client/githubclient.py
+++ b/nodestream_github/client/githubclient.py
@@ -343,7 +343,7 @@ class GithubRestApiClient:
             date_filter = (
                 f" created:>={(datetime.now() - relativedelta(**lookback_period)).strftime('%Y-%m-%d')}"
                 if lookback_period
-                else ''
+                else ""
             )
             search_phrase = f"{actions_phrase}{date_filter}"
 

--- a/nodestream_github/client/githubclient.py
+++ b/nodestream_github/client/githubclient.py
@@ -7,6 +7,7 @@ import json
 import logging
 from collections.abc import AsyncGenerator
 from enum import Enum
+from typing import List
 
 import httpx
 from limits import RateLimitItem, RateLimitItemPerMinute
@@ -322,17 +323,15 @@ class GithubRestApiClient:
             _fetch_problem("all organizations", e)
 
     async def fetch_enterprise_audit_log(
-        self, enterprise_name, events
+        self, enterprise_name: str, actions: List[str]
     ) -> AsyncGenerator[types.GithubAuditLog]:
         """Fetches enterprise-wide audit log data
 
         https://docs.github.com/en/enterprise-cloud@latest/rest/enterprise-admin/audit-log?apiVersion=2022-11-28#get-the-audit-log-for-an-enterprise
         """
         try:
-            params = {}
-            phrase = ", ".join(events)
-            if phrase:
-                params["phrase"] = phrase
+            phrase = ' '.join(f"action:{action}" for action in actions)
+            params = {"phrase": phrase} if phrase else {}
             async for audit in self._get_paginated(
                 f"enterprises/{enterprise_name}/audit-log", params=params
             ):

--- a/nodestream_github/client/githubclient.py
+++ b/nodestream_github/client/githubclient.py
@@ -6,11 +6,11 @@ An async client for accessing GitHub.
 import json
 import logging
 from collections.abc import AsyncGenerator
-from datetime import datetime
+from datetime import UTC, datetime
 from enum import Enum
 
 import httpx
-from dateutil.relativedelta import *
+from dateutil.relativedelta import relativedelta
 from limits import RateLimitItem, RateLimitItemPerMinute
 from limits.aio.storage import MemoryStorage
 from limits.aio.strategies import MovingWindowRateLimiter, RateLimiter
@@ -341,7 +341,8 @@ class GithubRestApiClient:
             actions_phrase = " ".join(f"action:{action}" for action in actions)
             # adding lookback_period based filtering
             date_filter = (
-                f" created:>={(datetime.now() - relativedelta(**lookback_period)).strftime('%Y-%m-%d')}"
+                f" created:>={(datetime.now(tz=UTC) - relativedelta(**lookback_period))
+                .strftime('%Y-%m-%d')}"
                 if lookback_period
                 else ""
             )

--- a/nodestream_github/client/githubclient.py
+++ b/nodestream_github/client/githubclient.py
@@ -335,7 +335,7 @@ class GithubRestApiClient:
         https://docs.github.com/en/enterprise-cloud@latest/rest/enterprise-admin/audit-log?apiVersion=2022-11-28#get-the-audit-log-for-an-enterprise
         """
         try:
-            phrase = ' '.join(f"action:{action}" for action in actions)
+            phrase = " ".join(f"action:{action}" for action in actions)
             params = {"phrase": phrase} if phrase else {}
             async for audit in self._get_paginated(
                 f"enterprises/{enterprise_name}/audit-log", params=params

--- a/nodestream_github/client/githubclient.py
+++ b/nodestream_github/client/githubclient.py
@@ -321,6 +321,25 @@ class GithubRestApiClient:
         except httpx.HTTPError as e:
             _fetch_problem("all organizations", e)
 
+    async def fetch_enterprise_audit_log(
+        self, enterprise_name, events
+    ) -> AsyncGenerator[types.GithubAuditLog]:
+        """Fetches enterprise-wide audit log data
+
+        https://docs.github.com/en/enterprise-cloud@latest/rest/enterprise-admin/audit-log?apiVersion=2022-11-28#get-the-audit-log-for-an-enterprise
+        """
+        try:
+            params = {}
+            phrase = ", ".join(events)
+            if phrase:
+                params["phrase"] = phrase
+            async for audit in self._get_paginated(
+                f"enterprises/{enterprise_name}/audit-log", params=params
+            ):
+                yield audit
+        except httpx.HTTPError as e:
+            _fetch_problem("audit log", e)
+
     async def fetch_full_org(self, org_login: str) -> types.GithubOrg | None:
         """Fetches the complete org record.
 

--- a/nodestream_github/client/githubclient.py
+++ b/nodestream_github/client/githubclient.py
@@ -341,11 +341,11 @@ class GithubRestApiClient:
             actions_phrase = " ".join(f"action:{action}" for action in actions)
             # adding lookback_period based filtering
             date_filter = (
-                f"created:>={(datetime.now() - relativedelta(**lookback_period)).strftime('%Y-%m-%d')}"
+                f" created:>={(datetime.now() - relativedelta(**lookback_period)).strftime('%Y-%m-%d')}"
                 if lookback_period
                 else ''
             )
-            search_phrase = f"{actions_phrase} {date_filter}"
+            search_phrase = f"{actions_phrase}{date_filter}"
 
             params = {"phrase": search_phrase} if search_phrase else {}
 

--- a/nodestream_github/github_audit.yaml
+++ b/nodestream_github/github_audit.yaml
@@ -1,0 +1,19 @@
+- implementation: nodestream_github:GithubAuditLogExtractor
+  arguments:
+    github_hostname: !config 'github_hostname'
+    auth_token: !config 'auth_token'
+    user_agent: !config 'user_agent'
+    enterprise_name: 'intuit'
+- implementation: nodestream.interpreting:Interpreter
+  arguments:
+    interpretations:
+    - type: source_node
+      node_type: BranchProtectionPolicyChange
+      key_normalization:
+        do_lowercase_strings: true
+      key:
+        node_id: !jmespath 'node_id'
+    - type: properties
+      properties:
+        timestamp: !jmespath 'timestamp'
+        action: !jmespath 'action'

--- a/nodestream_github/github_audit.yaml
+++ b/nodestream_github/github_audit.yaml
@@ -3,17 +3,24 @@
     github_hostname: !config 'github_hostname'
     auth_token: !config 'auth_token'
     user_agent: !config 'user_agent'
-    enterprise_name: 'intuit'
+    enterprise_name: 'test-enterprise'
+    actions:
+      - protected_branch.create
+      - repo.download_zip
+    lookback_period:
+      days: 1
+
 - implementation: nodestream.interpreting:Interpreter
   arguments:
     interpretations:
     - type: source_node
       node_type: BranchProtectionPolicyChange
-      key_normalization:
-        do_lowercase_strings: true
       key:
-        node_id: !jmespath 'node_id'
+        timestamp: !jmespath 'timestamp'
+        actor: !jmespath 'actor'
+        action: !jmespath 'action'
     - type: properties
       properties:
-        timestamp: !jmespath 'timestamp'
-        action: !jmespath 'action'
+        org: !jmespath 'org'
+        repo: !jmespath 'repo'
+        created_at: !jmespath 'created_at'

--- a/nodestream_github/types/__init__.py
+++ b/nodestream_github/types/__init__.py
@@ -1,4 +1,5 @@
 from .github import (
+    GithubAuditLog,
     GithubOrg,
     GithubOrgSummary,
     GithubRepo,
@@ -23,6 +24,7 @@ __all__ = [
     "GithubRepo",
     "GithubTeam",
     "GithubTeamSummary",
+    "GithubAuditLog",
     "GithubUser",
     "HeaderTypes",
     "JSONType",

--- a/nodestream_github/types/github.py
+++ b/nodestream_github/types/github.py
@@ -11,6 +11,7 @@ GithubUser: TypeAlias = JSONType
 Webhook: TypeAlias = JSONType
 GithubTeam: TypeAlias = JSONType
 GithubTeamSummary: TypeAlias = JSONType
+GithubAuditLog: TypeAlias = JSONType
 
 LanguageRecord: TypeAlias = JSONType
 OrgRecord: TypeAlias = JSONType

--- a/tests/data/audit.py
+++ b/tests/data/audit.py
@@ -1,71 +1,62 @@
-from nodestream_github.types import GithubAuditLog
+GITHUB_AUDIT = [
+    {
+        "@timestamp": 1606929874512,
+        "action": "team.add_member",
+        "actor": "octocat",
+        "created_at": 1606929874512,
+        "_document_id": "xJJFlFOhQ6b-5vaAFy9Rjw",
+        "org": "octo-corp",
+        "team": "octo-corp/example-team",
+        "user": "monalisa",
+    },
+    {
+        "@timestamp": 1606507117008,
+        "action": "org.create",
+        "actor": "octocat",
+        "created_at": 1606507117008,
+        "_document_id": "Vqvg6kZ4MYqwWRKFDzlMoQ",
+        "org": "octocat-test-org",
+    },
+    {
+        "@timestamp": 1605719148837,
+        "action": "repo.destroy",
+        "actor": "monalisa",
+        "created_at": 1605719148837,
+        "_document_id": "LwW2vpJZCDS-WUmo9Z-ifw",
+        "org": "mona-org",
+        "repo": "mona-org/mona-test-repo",
+        "visibility": "private",
+    },
+]
 
 
-def audit() -> GithubAuditLog:
-    return [
-        {
-            "@timestamp": 1606929874512,
-            "action": "team.add_member",
-            "actor": "octocat",
-            "created_at": 1606929874512,
-            "_document_id": "xJJFlFOhQ6b-5vaAFy9Rjw",
-            "org": "octo-corp",
-            "team": "octo-corp/example-team",
-            "user": "monalisa",
-        },
-        {
-            "@timestamp": 1606507117008,
-            "action": "org.create",
-            "actor": "octocat",
-            "created_at": 1606507117008,
-            "_document_id": "Vqvg6kZ4MYqwWRKFDzlMoQ",
-            "org": "octocat-test-org",
-        },
-        {
-            "@timestamp": 1605719148837,
-            "action": "repo.destroy",
-            "actor": "monalisa",
-            "created_at": 1605719148837,
-            "_document_id": "LwW2vpJZCDS-WUmo9Z-ifw",
-            "org": "mona-org",
-            "repo": "mona-org/mona-test-repo",
-            "visibility": "private",
-        },
-    ]
-
-
-def audit_expected_output() -> GithubAuditLog:
-    return [
-        {
-            "timestamp": 1606929874512,
-            "action": "team.add_member",
-            "actor": "octocat",
-            "created_at": 1606929874512,
-            "_document_id": "xJJFlFOhQ6b-5vaAFy9Rjw",
-            "org": "octo-corp",
-            "team": "octo-corp/example-team",
-            "user": "monalisa",
-        },
-        {
-            "timestamp": 1606507117008,
-            "action": "org.create",
-            "actor": "octocat",
-            "created_at": 1606507117008,
-            "_document_id": "Vqvg6kZ4MYqwWRKFDzlMoQ",
-            "org": "octocat-test-org",
-        },
-        {
-            "timestamp": 1605719148837,
-            "action": "repo.destroy",
-            "actor": "monalisa",
-            "created_at": 1605719148837,
-            "_document_id": "LwW2vpJZCDS-WUmo9Z-ifw",
-            "org": "mona-org",
-            "repo": "mona-org/mona-test-repo",
-            "visibility": "private",
-        },
-    ]
-
-
-GITHUB_AUDIT = audit()
-GITHUB_EXPECTED_OUTPUT = audit_expected_output()
+GITHUB_EXPECTED_OUTPUT = [
+    {
+        "timestamp": 1606929874512,
+        "action": "team.add_member",
+        "actor": "octocat",
+        "created_at": 1606929874512,
+        "_document_id": "xJJFlFOhQ6b-5vaAFy9Rjw",
+        "org": "octo-corp",
+        "team": "octo-corp/example-team",
+        "user": "monalisa",
+    },
+    {
+        "timestamp": 1606507117008,
+        "action": "org.create",
+        "actor": "octocat",
+        "created_at": 1606507117008,
+        "_document_id": "Vqvg6kZ4MYqwWRKFDzlMoQ",
+        "org": "octocat-test-org",
+    },
+    {
+        "timestamp": 1605719148837,
+        "action": "repo.destroy",
+        "actor": "monalisa",
+        "created_at": 1605719148837,
+        "_document_id": "LwW2vpJZCDS-WUmo9Z-ifw",
+        "org": "mona-org",
+        "repo": "mona-org/mona-test-repo",
+        "visibility": "private",
+    },
+]

--- a/tests/data/audit.py
+++ b/tests/data/audit.py
@@ -34,4 +34,37 @@ def audit() -> GithubAuditLog:
     ]
 
 
+def audit_expected_output() -> GithubAuditLog:
+    return [
+        {
+            "timestamp": 1606929874512,
+            "action": "team.add_member",
+            "actor": "octocat",
+            "created_at": 1606929874512,
+            "_document_id": "xJJFlFOhQ6b-5vaAFy9Rjw",
+            "org": "octo-corp",
+            "team": "octo-corp/example-team",
+            "user": "monalisa",
+        },
+        {
+            "timestamp": 1606507117008,
+            "action": "org.create",
+            "actor": "octocat",
+            "created_at": 1606507117008,
+            "_document_id": "Vqvg6kZ4MYqwWRKFDzlMoQ",
+            "org": "octocat-test-org",
+        },
+        {
+            "timestamp": 1605719148837,
+            "action": "repo.destroy",
+            "actor": "monalisa",
+            "created_at": 1605719148837,
+            "_document_id": "LwW2vpJZCDS-WUmo9Z-ifw",
+            "org": "mona-org",
+            "repo": "mona-org/mona-test-repo",
+            "visibility": "private",
+        },
+    ]
+
 GITHUB_AUDIT = audit()
+GITHUB_EXPECTED_OUTPUT = audit_expected_output()

--- a/tests/data/audit.py
+++ b/tests/data/audit.py
@@ -1,0 +1,37 @@
+from nodestream_github.types import GithubAuditLog
+
+
+def audit() -> GithubAuditLog:
+    return [
+        {
+            "@timestamp": 1606929874512,
+            "action": "team.add_member",
+            "actor": "octocat",
+            "created_at": 1606929874512,
+            "_document_id": "xJJFlFOhQ6b-5vaAFy9Rjw",
+            "org": "octo-corp",
+            "team": "octo-corp/example-team",
+            "user": "monalisa",
+        },
+        {
+            "@timestamp": 1606507117008,
+            "action": "org.create",
+            "actor": "octocat",
+            "created_at": 1606507117008,
+            "_document_id": "Vqvg6kZ4MYqwWRKFDzlMoQ",
+            "org": "octocat-test-org",
+        },
+        {
+            "@timestamp": 1605719148837,
+            "action": "repo.destroy",
+            "actor": "monalisa",
+            "created_at": 1605719148837,
+            "_document_id": "LwW2vpJZCDS-WUmo9Z-ifw",
+            "org": "mona-org",
+            "repo": "mona-org/mona-test-repo",
+            "visibility": "private",
+        },
+    ]
+
+
+GITHUB_AUDIT = audit()

--- a/tests/data/audit.py
+++ b/tests/data/audit.py
@@ -66,5 +66,6 @@ def audit_expected_output() -> GithubAuditLog:
         },
     ]
 
+
 GITHUB_AUDIT = audit()
 GITHUB_EXPECTED_OUTPUT = audit_expected_output()

--- a/tests/mocks/githubrest.py
+++ b/tests/mocks/githubrest.py
@@ -186,6 +186,6 @@ class GithubHttpxMock:
             **kwargs,
         )
 
-    def get_enterprise_audit_logs(self, **kwargs):
+    def get_enterprise_audit_logs(self, **kwargs: any):
         url = f"{self.base_url}/enterprises/test-enterprise/audit-log?per_page=100&phrase=protected_branch.create"
         self.add_response(url=url, **kwargs)

--- a/tests/mocks/githubrest.py
+++ b/tests/mocks/githubrest.py
@@ -187,6 +187,8 @@ class GithubHttpxMock:
         )
 
     def get_enterprise_audit_logs(self, **kwargs: any):
-        url = (f"{self.base_url}/enterprises/test-enterprise"
-               f"/audit-log?per_page=100&phrase=action:protected_branch.create")
+        url = (
+            f"{self.base_url}/enterprises/test-enterprise"
+            f"/audit-log?per_page=100&phrase=action:protected_branch.create"
+        )
         self.add_response(url=url, **kwargs)

--- a/tests/mocks/githubrest.py
+++ b/tests/mocks/githubrest.py
@@ -187,5 +187,6 @@ class GithubHttpxMock:
         )
 
     def get_enterprise_audit_logs(self, **kwargs: any):
-        url = f"{self.base_url}/enterprises/test-enterprise/audit-log?per_page=100&phrase=action:protected_branch.create"
+        url = (f"{self.base_url}/enterprises/test-enterprise"
+               f"/audit-log?per_page=100&phrase=action:protected_branch.create")
         self.add_response(url=url, **kwargs)

--- a/tests/mocks/githubrest.py
+++ b/tests/mocks/githubrest.py
@@ -187,5 +187,5 @@ class GithubHttpxMock:
         )
 
     def get_enterprise_audit_logs(self, **kwargs: any):
-        url = f"{self.base_url}/enterprises/test-enterprise/audit-log?per_page=100&phrase=protected_branch.create"
+        url = f"{self.base_url}/enterprises/test-enterprise/audit-log?per_page=100&phrase=action:protected_branch.create"
         self.add_response(url=url, **kwargs)

--- a/tests/mocks/githubrest.py
+++ b/tests/mocks/githubrest.py
@@ -168,3 +168,7 @@ class GithubHttpxMock:
             url=f"{self.base_url}/users/{user_login}/repos?per_page=100&{type_param}",
             **kwargs,
         )
+
+    def get_enterprise_audit_logs(self, **kwargs):
+        url = f"{self.base_url}/enterprises/test-enterprise/audit-log?per_page=100&phrase=protected_branch.create"
+        self.add_response(url=url, **kwargs)

--- a/tests/mocks/githubrest.py
+++ b/tests/mocks/githubrest.py
@@ -190,7 +190,7 @@ class GithubHttpxMock:
             **kwargs,
         )
 
-    def get_enterprise_audit_logs(self, **kwargs: any):
+    def get_enterprise_audit_logs(self, **kwargs: dict[str, Any]):
         url = (
             f"{self.base_url}/enterprises/test-enterprise"
             f"/audit-log?per_page=100&phrase=action:protected_branch.create"

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -18,7 +18,7 @@ def audit_client() -> GithubAuditLogExtractor:
         max_retries=0,
         per_page=DEFAULT_PER_PAGE,
         enterprise_name="test-enterprise",
-        events=["protected_branch.create"],
+        actions=["protected_branch.create"],
     )
 
 

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -1,4 +1,3 @@
-import httpx
 import pytest
 
 from nodestream_github import GithubAuditLogExtractor

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -1,0 +1,33 @@
+import httpx
+import pytest
+
+from nodestream_github import GithubAuditLogExtractor
+from tests.data.audit import GITHUB_AUDIT
+from tests.mocks.githubrest import (
+    DEFAULT_HOSTNAME,
+    DEFAULT_PER_PAGE,
+    GithubHttpxMock,
+)
+
+
+@pytest.fixture
+def audit_client() -> GithubAuditLogExtractor:
+    return GithubAuditLogExtractor(
+        auth_token="test-token",
+        github_hostname=DEFAULT_HOSTNAME,
+        user_agent="test-agent",
+        max_retries=0,
+        per_page=DEFAULT_PER_PAGE,
+        enterprise_name="test-enterprise",
+        events=["protected_branch.create"],
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_audit(
+    audit_client: GithubAuditLogExtractor, gh_rest_mock: GithubHttpxMock
+):
+    gh_rest_mock.get_enterprise_audit_logs(status_code=200, json=GITHUB_AUDIT)
+
+    all_records = [record async for record in audit_client.extract_records()]
+    assert all_records == GITHUB_AUDIT

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -10,7 +10,7 @@ from tests.mocks.githubrest import (
 
 
 @pytest.fixture
-def audit_client() -> GithubAuditLogExtractor:
+def audit_extractor() -> GithubAuditLogExtractor:
     return GithubAuditLogExtractor(
         auth_token="test-token",
         github_hostname=DEFAULT_HOSTNAME,
@@ -24,9 +24,9 @@ def audit_client() -> GithubAuditLogExtractor:
 
 @pytest.mark.asyncio
 async def test_get_audit(
-    audit_client: GithubAuditLogExtractor, gh_rest_mock: GithubHttpxMock
+    audit_extractor: GithubAuditLogExtractor, gh_rest_mock: GithubHttpxMock
 ):
     gh_rest_mock.get_enterprise_audit_logs(status_code=200, json=GITHUB_AUDIT)
 
-    all_records = [record async for record in audit_client.extract_records()]
+    all_records = [record async for record in audit_extractor.extract_records()]
     assert all_records == GITHUB_EXPECTED_OUTPUT

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -1,7 +1,7 @@
 import pytest
 
 from nodestream_github import GithubAuditLogExtractor
-from tests.data.audit import GITHUB_AUDIT
+from tests.data.audit import GITHUB_AUDIT, GITHUB_EXPECTED_OUTPUT
 from tests.mocks.githubrest import (
     DEFAULT_HOSTNAME,
     DEFAULT_PER_PAGE,
@@ -29,4 +29,4 @@ async def test_get_audit(
     gh_rest_mock.get_enterprise_audit_logs(status_code=200, json=GITHUB_AUDIT)
 
     all_records = [record async for record in audit_client.extract_records()]
-    assert all_records == GITHUB_AUDIT
+    assert all_records == GITHUB_EXPECTED_OUTPUT

--- a/tests/test_orgs.py
+++ b/tests/test_orgs.py
@@ -88,7 +88,7 @@ BASE_EXPECTED_GITHUB_ORG = {
 
 
 @pytest.fixture
-def org_client() -> GithubOrganizationsExtractor:
+def org_extractor() -> GithubOrganizationsExtractor:
     return GithubOrganizationsExtractor(
         auth_token="test-token",
         github_hostname=DEFAULT_HOSTNAME,
@@ -100,7 +100,7 @@ def org_client() -> GithubOrganizationsExtractor:
 
 @pytest.mark.asyncio
 async def test_orgs_continue_through_org_detail_status_fail(
-    org_client: GithubOrganizationsExtractor, gh_rest_mock: GithubHttpxMock
+    org_extractor: GithubOrganizationsExtractor, gh_rest_mock: GithubHttpxMock
 ):
     gh_rest_mock.all_orgs(json=[GITHUB_ORG_SUMMARY, EXAMPLE_ORG_SUMMARY])
     gh_rest_mock.get_org(org_name="github", status_code=httpx.codes.NOT_FOUND)
@@ -118,12 +118,12 @@ async def test_orgs_continue_through_org_detail_status_fail(
     )
     gh_rest_mock.get_repos_for_org(org_name="example", json=[])
 
-    assert len([record async for record in org_client.extract_records()]) == 1
+    assert len([record async for record in org_extractor.extract_records()]) == 1
 
 
 @pytest.mark.asyncio
 async def test_orgs_continue_through_org_member_status_fail(
-    org_client: GithubOrganizationsExtractor, gh_rest_mock: GithubHttpxMock
+    org_extractor: GithubOrganizationsExtractor, gh_rest_mock: GithubHttpxMock
 ):
     gh_rest_mock.all_orgs(json=[GITHUB_ORG_SUMMARY])
     gh_rest_mock.get_org(org_name="github", json=GITHUB_ORG)
@@ -141,7 +141,7 @@ async def test_orgs_continue_through_org_member_status_fail(
     )
     gh_rest_mock.get_repos_for_org(org_name="github", json=[HELLO_WORLD_REPO])
 
-    assert [record async for record in org_client.extract_records()] == [
+    assert [record async for record in org_extractor.extract_records()] == [
         BASE_EXPECTED_GITHUB_ORG
         | {
             "members": [{
@@ -165,7 +165,7 @@ async def test_orgs_continue_through_org_member_status_fail(
 
 @pytest.mark.asyncio
 async def test_orgs_continue_through_org_member_status_fail_second(
-    org_client: GithubOrganizationsExtractor, gh_rest_mock: GithubHttpxMock
+    org_extractor: GithubOrganizationsExtractor, gh_rest_mock: GithubHttpxMock
 ):
     gh_rest_mock.all_orgs(json=[GITHUB_ORG_SUMMARY])
     gh_rest_mock.get_org(org_name="github", json=GITHUB_ORG)
@@ -183,7 +183,7 @@ async def test_orgs_continue_through_org_member_status_fail_second(
     )
     gh_rest_mock.get_repos_for_org(org_name="github", json=[])
 
-    assert [record async for record in org_client.extract_records()] == [
+    assert [record async for record in org_extractor.extract_records()] == [
         BASE_EXPECTED_GITHUB_ORG
         | {
             "members": [{
@@ -198,7 +198,7 @@ async def test_orgs_continue_through_org_member_status_fail_second(
 
 @pytest.mark.asyncio
 async def test_orgs_continue_through_org_repo_status_fail(
-    org_client: GithubOrganizationsExtractor, gh_rest_mock: GithubHttpxMock
+    org_extractor: GithubOrganizationsExtractor, gh_rest_mock: GithubHttpxMock
 ):
     gh_rest_mock.all_orgs(json=[GITHUB_ORG_SUMMARY])
     gh_rest_mock.get_org(org_name="github", json=GITHUB_ORG)
@@ -219,7 +219,7 @@ async def test_orgs_continue_through_org_repo_status_fail(
         status_code=httpx.codes.NOT_FOUND,
     )
 
-    assert [record async for record in org_client.extract_records()] == [
+    assert [record async for record in org_extractor.extract_records()] == [
         BASE_EXPECTED_GITHUB_ORG
         | {
             "members": [{
@@ -234,7 +234,7 @@ async def test_orgs_continue_through_org_repo_status_fail(
 
 @pytest.mark.asyncio
 async def test_orgs_continue_through_org_detail_connection_fail(
-    org_client: GithubOrganizationsExtractor, gh_rest_mock: GithubHttpxMock
+    org_extractor: GithubOrganizationsExtractor, gh_rest_mock: GithubHttpxMock
 ):
     gh_rest_mock.all_orgs(json=[GITHUB_ORG_SUMMARY, EXAMPLE_ORG_SUMMARY])
     gh_rest_mock.add_exception(
@@ -255,12 +255,12 @@ async def test_orgs_continue_through_org_detail_connection_fail(
     )
     gh_rest_mock.get_repos_for_org(org_name="example", json=[])
 
-    assert len([record async for record in org_client.extract_records()]) == 1
+    assert len([record async for record in org_extractor.extract_records()]) == 1
 
 
 @pytest.mark.asyncio
 async def test_get_orgs(
-    org_client: GithubOrganizationsExtractor, gh_rest_mock: GithubHttpxMock
+    org_extractor: GithubOrganizationsExtractor, gh_rest_mock: GithubHttpxMock
 ):
     gh_rest_mock.all_orgs(json=[GITHUB_ORG_SUMMARY])
     gh_rest_mock.get_org(org_name="github", json=GITHUB_ORG)
@@ -276,7 +276,7 @@ async def test_get_orgs(
     )
     gh_rest_mock.get_repos_for_org(org_name="github", json=[HELLO_WORLD_REPO])
 
-    all_records = [record async for record in org_client.extract_records()]
+    all_records = [record async for record in org_extractor.extract_records()]
     assert all_records == [
         BASE_EXPECTED_GITHUB_ORG
         | {
@@ -311,7 +311,7 @@ async def test_get_orgs(
 async def test_skip_members(
     gh_rest_mock: GithubHttpxMock,
 ):
-    org_client = GithubOrganizationsExtractor(
+    org_extractor = GithubOrganizationsExtractor(
         auth_token="test-token",
         github_hostname=DEFAULT_HOSTNAME,
         user_agent="test-agent",
@@ -324,7 +324,7 @@ async def test_skip_members(
     gh_rest_mock.get_org(org_name="github", json=GITHUB_ORG)
     gh_rest_mock.get_repos_for_org(org_name="github", json=[HELLO_WORLD_REPO])
 
-    all_records = [record async for record in org_client.extract_records()]
+    all_records = [record async for record in org_extractor.extract_records()]
     assert all_records == [
         BASE_EXPECTED_GITHUB_ORG
         | {
@@ -344,7 +344,7 @@ async def test_skip_members(
 
 @pytest.mark.asyncio
 async def test_skip_repositories(gh_rest_mock: GithubHttpxMock):
-    org_client = GithubOrganizationsExtractor(
+    org_extractor = GithubOrganizationsExtractor(
         auth_token="test-token",
         github_hostname=DEFAULT_HOSTNAME,
         include_repositories=False,  # putting the here to test kwargs interaction
@@ -366,7 +366,7 @@ async def test_skip_repositories(gh_rest_mock: GithubHttpxMock):
         role=OrgMemberRole.MEMBER,
     )
 
-    all_records = [record async for record in org_client.extract_records()]
+    all_records = [record async for record in org_extractor.extract_records()]
     assert all_records == [
         BASE_EXPECTED_GITHUB_ORG
         | {

--- a/tests/test_repos.py
+++ b/tests/test_repos.py
@@ -16,7 +16,7 @@ TEST_USER = user(user_login="bweaver", user_id=3)
 
 
 @pytest.fixture
-def repo_client() -> GithubReposExtractor:
+def repo_extractor() -> GithubReposExtractor:
     return GithubReposExtractor(
         auth_token="test-token",
         github_hostname=DEFAULT_HOSTNAME,
@@ -128,7 +128,7 @@ async def test_pull_user_repos(gh_rest_mock: GithubHttpxMock):
 
 @pytest.mark.asyncio
 async def test_extract_records(
-    repo_client: GithubReposExtractor, gh_rest_mock: GithubHttpxMock
+    repo_extractor: GithubReposExtractor, gh_rest_mock: GithubHttpxMock
 ):
     gh_rest_mock.all_repos(
         json=[HELLO_WORLD_REPO, repo(owner=GITHUB_ORG_SUMMARY, repo_name="Hello-Moon")],
@@ -177,7 +177,7 @@ async def test_extract_records(
         affiliation=CollaboratorAffiliation.OUTSIDE,
         json=[TEST_USER],
     )
-    assert [record async for record in repo_client.extract_records()] == [
+    assert [record async for record in repo_extractor.extract_records()] == [
         {
             "archive_url": (
                 "https://HOSTNAME/repos/octocat/Hello-World/{archive_format}{/ref}"

--- a/tests/test_teams.py
+++ b/tests/test_teams.py
@@ -10,7 +10,7 @@ from tests.mocks.githubrest import DEFAULT_HOSTNAME, DEFAULT_PER_PAGE, GithubHtt
 
 
 @pytest.fixture
-def team_client() -> GithubTeamsExtractor:
+def teams_extractor() -> GithubTeamsExtractor:
     return GithubTeamsExtractor(
         auth_token="test-token",
         github_hostname=DEFAULT_HOSTNAME,
@@ -22,7 +22,7 @@ def team_client() -> GithubTeamsExtractor:
 
 @pytest.mark.asyncio
 async def test_extract_records(
-    team_client: GithubTeamsExtractor, gh_rest_mock: GithubHttpxMock
+    teams_extractor: GithubTeamsExtractor, gh_rest_mock: GithubHttpxMock
 ):
     gh_rest_mock.all_orgs(json=[GITHUB_ORG_SUMMARY])
     gh_rest_mock.list_teams_for_org(
@@ -50,7 +50,7 @@ async def test_extract_records(
         json=[HELLO_WORLD_REPO],
     )
 
-    assert [record async for record in team_client.extract_records()] == [{
+    assert [record async for record in teams_extractor.extract_records()] == [{
         "created_at": "2017-07-14T16:53:42Z",
         "description": "A great team.",
         "html_url": "https://github.com/orgs/github/teams/justice-league",

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -11,7 +11,7 @@ from tests.mocks.githubrest import DEFAULT_HOSTNAME, GithubHttpxMock
 
 
 @pytest.fixture
-def user_client() -> GithubUserExtractor:
+def user_extractor() -> GithubUserExtractor:
     return GithubUserExtractor(
         auth_token="test-token",
         github_hostname=DEFAULT_HOSTNAME,
@@ -29,7 +29,7 @@ async def to_list(async_generator: AsyncGenerator) -> list:
 
 @pytest.mark.asyncio
 async def test_github_user_extractor(
-    user_client: GithubUserExtractor, gh_rest_mock: GithubHttpxMock
+    user_extractor: GithubUserExtractor, gh_rest_mock: GithubHttpxMock
 ):
 
     gh_rest_mock.all_users(json=[OCTOCAT_USER])
@@ -39,7 +39,7 @@ async def test_github_user_extractor(
         json=[HELLO_WORLD_REPO],
     )
 
-    actual = [record async for record in user_client.extract_records()]
+    actual = [record async for record in user_extractor.extract_records()]
 
     assert actual == [
         OCTOCAT_USER
@@ -58,7 +58,7 @@ async def test_github_user_extractor(
 
 @pytest.mark.asyncio
 async def test_github_user_extractor_repo_fail(
-    user_client: GithubUserExtractor,
+    user_extractor: GithubUserExtractor,
     gh_rest_mock: GithubHttpxMock,
 ):
 
@@ -68,6 +68,6 @@ async def test_github_user_extractor_repo_fail(
         type_param=UserRepoType.OWNER,
         status_code=httpx.codes.SERVICE_UNAVAILABLE,
     )
-    actual = [user async for user in user_client.extract_records()]
+    actual = [user async for user in user_extractor.extract_records()]
 
     assert actual == [OCTOCAT_USER | {"repositories": []}]


### PR DESCRIPTION
# Summary of Change
 
Adding an Audit Log Extractor for the GitHub plugin. I was able to test this locally and it seems to work as expected! As of now, we will support filtering the audit log based on different action(s). There may be some room to add more filtering based on time as well, but at the moment I don't think it'll be required.

## Before Review
- [x] Unit Tests are Added/Updated and meet at-least 85% coverage criteria for that feature

## Before Merge
- [x] Ran/Functionally Tested in Dev Environment
- [x] Documentation Is Updated (Where Appropriate)
